### PR TITLE
Bump dependencies to incorporate ponyc FFI changes

### DIFF
--- a/corral.json
+++ b/corral.json
@@ -6,11 +6,11 @@
     },
     {
       "locator": "github.com/ponylang/regex.git",
-      "version": "1.1.1"
+      "version": "1.1.2"
     },
     {
       "locator": "github.com/ponylang/valbytes.git",
-      "version": "0.5.1"
+      "version": "0.6.0"
     }
   ],
   "info": {}

--- a/lock.json
+++ b/lock.json
@@ -1,13 +1,20 @@
 {
   "locks": [
     {
-      "locator": "github.com/ponylang/peg.git"
+      "locator": "github.com/ponylang/peg.git",
+      "revision": "0.1.1"
     },
     {
-      "locator": "github.com/ponylang/regex.git"
+      "locator": "github.com/ponylang/regex.git",
+      "revision": "1.1.2"
     },
     {
-      "locator": "github.com/ponylang/valbytes.git"
+      "locator": "github.com/ponylang/valbytes.git",
+      "revision": "0.6.0"
+    },
+    {
+      "locator": "github.com/ponylang/ponycheck.git",
+      "revision": "0.6.0"
     }
   ]
 }


### PR DESCRIPTION
This makes the library work in ponyc 0.41.0 and up by integrating the changes related to RFC 68